### PR TITLE
Archive agent-skill-loader and sync skill specs

### DIFF
--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-13

--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/design.md
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The task runner agent currently receives one global system prompt for all tasks. The system prompt is stored in the `Setting` table and injected into the task runner container as `/workspace/system_prompt.txt`. The agent already has access to the backend MCP server (exposing `new_task`, `task_status`, `task_output` tools) via the `/mcp` endpoint.
+
+The goal is to let admins define reusable prompt templates ("skills") that the agent can discover and load at runtime via MCP tools, keeping the base system prompt lean while allowing specialised behaviour per task.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Admin can create, edit, and delete skills via the settings UI
+- Agent can list available skills (name + description only) via an MCP tool
+- Agent can load a specific skill's full instructions via an MCP tool
+- System prompt tells the agent that skills exist and how to use them
+
+**Non-Goals:**
+- Per-task skill assignment at creation time (future enhancement)
+- Skill versioning or change history
+- Skill chaining / composition (agent can load multiple skills, but no formal dependency system)
+- Skill-specific MCP server configuration (skills only provide instructions, not tool access)
+
+## Decision: Store skills in the existing Setting table
+
+Skills will be stored as a single JSON array under the `skills` key in the `Setting` table, following the same pattern as `mcp_servers` and `credentials`. Each skill entry contains `id` (UUID), `name`, `description`, and `instructions`.
+
+**Why not a separate Skill model/table?** The current settings pattern (JSONB value in `Setting`) is well-established for admin-managed configuration. Skills are admin-managed prompt templates — closer to configuration than domain entities. A separate table would require a new migration, new API endpoints, and more frontend routing. The settings approach reuses existing infrastructure (`GET/PUT /api/settings`) and keeps the feature small.
+
+**Trade-off:** No individual skill URLs or foreign-key references from tasks. Acceptable since per-task skill assignment is a non-goal.
+
+## Decision: Two new MCP tools on the existing backend MCP server
+
+Add `list_skills` and `get_skill` to `backend/mcp_server.py`:
+
+- `list_skills() -> str` — Returns JSON array of `{name, description}` for all skills. Lightweight; the agent calls this to decide which skill to load.
+- `get_skill(name: str) -> str` — Returns the full `instructions` text for the named skill. The agent calls this when it decides a skill is relevant.
+
+**Why MCP tools instead of injecting into the system prompt?** This is the core design choice. Injecting all skills into the system prompt would scale poorly (each skill could be hundreds of tokens) and defeats the purpose of on-demand loading. MCP tools let the agent pull in only what it needs, similar to how Claude Code lists available skills but only expands them when invoked.
+
+**Why on the existing MCP server?** The backend already exposes an MCP endpoint at `/mcp` with API key auth. Adding tools there requires no new infrastructure, no new auth, and no new MCP server configuration.
+
+## Decision: Worker appends skill-awareness directive to system prompt
+
+The worker will append a brief directive to the system prompt (after the existing Perplexity injection, if active) telling the agent that skills are available and how to use them. This follows the established pattern in `worker.py` where Perplexity instructions are conditionally appended.
+
+The directive will only be appended if at least one skill is defined in settings. It will instruct the agent to:
+1. Call `list_skills` at the start of execution to see available skills
+2. Call `get_skill` if a skill seems relevant to the current task
+3. Follow the loaded skill's instructions
+
+## Decision: Skills management in the existing settings page
+
+Add a collapsible "Skills" section to `SettingsPage.vue`, similar to the existing "MCP Server Configuration" section. The UI will allow:
+- Viewing the list of skills (name + description)
+- Adding a new skill (name, description, instructions textarea)
+- Editing an existing skill
+- Deleting a skill
+
+This keeps all admin configuration in one place rather than introducing a new page/route.
+
+## Risks / Trade-offs
+
+- **Agent may not call list_skills:** The system prompt directive is advisory; the LLM might ignore it. Mitigation: keep the directive clear and concise; accept that skill loading is best-effort.
+- **Skill instructions quality depends on admin:** Poorly written skills could confuse the agent. Mitigation: not a technical risk — same as the existing system prompt being admin-managed.
+- **Settings JSONB size:** If many large skills are defined, the settings value grows. Mitigation: unlikely to be a practical issue; even 50 skills at 2KB each is only 100KB in JSONB. Revisit if needed.
+- **No validation of skill instructions:** Skills are free-text. Mitigation: acceptable for an admin-only feature; same as the system prompt field.
+
+## Migration Plan
+
+- Database: No migration needed — skills are stored in the existing `Setting` table as a new key.
+- Deployment: Standard deploy. The worker's skill directive is conditional (only appends if skills exist), so the feature is inert until an admin creates skills.
+- Rollback: Remove the code. Skills in settings are harmless configuration that gets ignored.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/proposal.md
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The task runner agent currently receives a single global system prompt for every task it executes. Users who want different behaviour for different kinds of work (e.g. "research this topic" vs "write code for X" vs "summarise this document") must either cram all instructions into one system prompt or manually edit it before each task. A skill library would let the admin define reusable prompt templates that the agent loads on demand at runtime — keeping context lean and instructions targeted, similar to how Claude Code loads slash-command skills only when invoked.
+
+## What Changes
+
+- Add a `Skill` database model to store named prompt templates with a short description (for discovery) and full instruction content (loaded on demand)
+- Expose `list_skills` and `get_skill` tools on the backend MCP server so the task runner agent can discover and load skills at runtime
+- Add a skills management section to the admin settings UI for creating, editing, and deleting skills
+- Augment the global system prompt with a brief directive telling the agent that skills are available and how to load them via MCP tools
+
+## Capabilities
+
+### New Capabilities
+
+- `skill-library`: Storage, retrieval, and management of reusable agent prompt templates (database model, API endpoints, admin UI)
+- `agent-skill-loading`: MCP tools for the agent to list and retrieve skills at runtime, plus system prompt augmentation
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- Backend: New `Skill` model + Alembic migration, new API endpoints for CRUD, two new MCP tools on the existing `/mcp` endpoint
+- Frontend: New skills management section on the settings page (or a dedicated page)
+- Worker: Minor change to append skill-awareness instructions to the system prompt (similar to existing Perplexity injection pattern)
+- Task runner: No changes — skills are loaded via existing MCP tool infrastructure

--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/specs/agent-skill-loading/spec.md
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/specs/agent-skill-loading/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: list_skills MCP tool
+The backend MCP server SHALL expose a `list_skills` tool that returns a JSON array of all defined skills, each containing only `name` and `description` fields (not the full instructions). If no skills are defined, it SHALL return an empty array. The tool SHALL require valid MCP API key authentication.
+
+#### Scenario: List skills with skills defined
+- **WHEN** the agent calls `list_skills` and two skills are defined ("researcher" and "code-reviewer")
+- **THEN** the tool returns `[{"name": "researcher", "description": "Conducts web research"}, {"name": "code-reviewer", "description": "Reviews code for quality"}]`
+
+#### Scenario: List skills with no skills defined
+- **WHEN** the agent calls `list_skills` and no skills are defined
+- **THEN** the tool returns `[]`
+
+### Requirement: get_skill MCP tool
+The backend MCP server SHALL expose a `get_skill` tool that accepts a `name` parameter and returns the full `instructions` text of the matching skill. If no skill matches the given name, the tool SHALL return an error message indicating the skill was not found.
+
+#### Scenario: Get existing skill
+- **WHEN** the agent calls `get_skill` with name "researcher" and that skill exists
+- **THEN** the tool returns the full instructions text of the "researcher" skill
+
+#### Scenario: Get non-existent skill
+- **WHEN** the agent calls `get_skill` with name "nonexistent" and no skill has that name
+- **THEN** the tool returns an error message: "Skill 'nonexistent' not found"
+
+### Requirement: Skill-awareness directive in system prompt
+When the worker prepares the system prompt for a task, it SHALL check if any skills are defined in settings. If at least one skill exists, the worker SHALL append a skill-awareness directive to the system prompt instructing the agent to: (1) call `list_skills` at the start of execution to discover available skills, (2) call `get_skill` to load a skill if one is relevant to the task, and (3) follow the loaded skill's instructions. If no skills are defined, the worker SHALL NOT append the directive.
+
+#### Scenario: Skills exist — directive appended
+- **WHEN** the worker prepares the system prompt and 2 skills are defined in settings
+- **THEN** the system prompt written to the container includes the original admin prompt followed by a skill-awareness directive
+
+#### Scenario: No skills defined — no directive
+- **WHEN** the worker prepares the system prompt and no skills are defined in settings
+- **THEN** the system prompt written to the container contains only the original admin prompt (and any other existing augmentations like Perplexity)
+
+#### Scenario: Directive placement after Perplexity
+- **WHEN** the worker prepares the system prompt and both Perplexity and skills are enabled
+- **THEN** the skill-awareness directive appears after the Perplexity instruction block

--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/specs/skill-library/spec.md
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/specs/skill-library/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Skill data structure
+Each skill SHALL be a JSON object with the following fields: `id` (UUID string, auto-generated), `name` (string, unique, non-empty), `description` (string, non-empty, brief summary for discovery), and `instructions` (string, non-empty, full prompt text). Skills SHALL be stored as a JSON array under the `skills` key in the `Setting` table.
+
+#### Scenario: Skill structure
+- **WHEN** a skill is stored in settings
+- **THEN** it contains `id`, `name`, `description`, and `instructions` fields
+
+#### Scenario: Skills key not yet set
+- **WHEN** no `skills` key exists in the Setting table
+- **THEN** the system treats the skill list as an empty array
+
+### Requirement: Skills included in settings API
+The `GET /api/settings` endpoint SHALL return the `skills` array in its response. The `PUT /api/settings` endpoint SHALL accept a `skills` field containing the full skills array and persist it to the `Setting` table under the `skills` key. Saving skills SHALL require admin role.
+
+#### Scenario: Get settings includes skills
+- **WHEN** an authenticated user calls `GET /api/settings` and two skills are defined
+- **THEN** the response includes a `skills` array with both skill objects
+
+#### Scenario: Get settings with no skills defined
+- **WHEN** an authenticated user calls `GET /api/settings` and no skills key exists
+- **THEN** the response includes `skills` as an empty array
+
+#### Scenario: Save skills via settings
+- **WHEN** an admin calls `PUT /api/settings` with `{"skills": [{"id": "...", "name": "researcher", "description": "Web research skill", "instructions": "You are a research assistant..."}]}`
+- **THEN** the skills array is persisted and returned in subsequent `GET /api/settings` responses
+
+#### Scenario: Non-admin cannot save skills
+- **WHEN** a non-admin user calls `PUT /api/settings` with a `skills` field
+- **THEN** the request is rejected with HTTP 403
+
+### Requirement: Skills management UI
+The settings page SHALL include a collapsible "Skills" section that displays all defined skills. The section SHALL allow the admin to add a new skill (providing name, description, and instructions), edit an existing skill, and delete a skill. Each skill in the list SHALL display its name and description. The instructions field SHALL use a multi-line textarea.
+
+#### Scenario: Skills section visible on settings page
+- **WHEN** an admin navigates to the settings page
+- **THEN** a "Skills" section is visible (collapsed or expanded) showing the count of defined skills
+
+#### Scenario: Add a new skill
+- **WHEN** the admin clicks "Add Skill" and fills in name "researcher", description "Conducts web research", and instructions "You are a research specialist..."
+- **THEN** the skill is added to the list and saved to the backend
+
+#### Scenario: Edit an existing skill
+- **WHEN** the admin clicks edit on a skill and changes its instructions
+- **THEN** the updated skill is saved to the backend
+
+#### Scenario: Delete a skill
+- **WHEN** the admin clicks delete on a skill and confirms
+- **THEN** the skill is removed from the list and the change is saved to the backend
+
+#### Scenario: Skill name uniqueness
+- **WHEN** the admin tries to add a skill with a name that already exists
+- **THEN** the UI shows a validation error and does not save

--- a/openspec/changes/archive/2026-02-13-agent-skill-loader/tasks.md
+++ b/openspec/changes/archive/2026-02-13-agent-skill-loader/tasks.md
@@ -1,0 +1,23 @@
+## 1. Backend — Settings & MCP Tools
+
+- [x] 1.1 Update `GET /api/settings` in `backend/main.py` to include `skills` (read from the `Setting` table with key `skills`, default to empty array if not set). Update `PUT /api/settings` to accept and persist the `skills` field.
+- [x] 1.2 Add `list_skills` and `get_skill` MCP tools to `backend/mcp_server.py`. `list_skills` returns `[{name, description}]` for all skills. `get_skill(name)` returns the full instructions text, or an error if not found. Both read from the `skills` setting.
+
+## 2. Backend — Worker
+
+- [x] 2.1 Update `process_task_in_container` in `backend/worker.py` to read the `skills` setting. If at least one skill is defined, append a skill-awareness directive to the system prompt (after any Perplexity block) instructing the agent to call `list_skills` and `get_skill` as needed.
+
+## 3. Frontend — Skills UI
+
+- [x] 3.1 Add a collapsible "Skills" section to `frontend/src/pages/SettingsPage.vue` with a list of existing skills (name + description), add/edit/delete functionality, and a textarea for instructions. Save via the existing `PUT /api/settings` endpoint.
+
+## 4. Tests
+
+- [x] 4.1 Add backend tests for the `skills` field in `GET/PUT /api/settings` (returns empty array when unset, round-trips correctly)
+- [x] 4.2 Add backend tests for `list_skills` and `get_skill` MCP tools (returns correct data, handles missing skill)
+- [x] 4.3 Add a backend test for the worker skill-awareness directive (appended when skills exist, omitted when none)
+- [x] 4.4 Add a frontend test for the skills section on the settings page (renders skills, add/edit/delete interactions)
+
+## 5. Verification
+
+- [x] 5.1 Rebuild with `docker compose up --build` and verify: create a skill in settings UI, create a task, confirm the agent calls `list_skills` and loads the skill via `get_skill` (check runner logs)

--- a/openspec/specs/agent-skill-loading/spec.md
+++ b/openspec/specs/agent-skill-loading/spec.md
@@ -1,0 +1,38 @@
+## Requirements
+
+### Requirement: list_skills MCP tool
+The backend MCP server SHALL expose a `list_skills` tool that returns a JSON array of all defined skills, each containing only `name` and `description` fields (not the full instructions). If no skills are defined, it SHALL return an empty array. The tool SHALL require valid MCP API key authentication.
+
+#### Scenario: List skills with skills defined
+- **WHEN** the agent calls `list_skills` and two skills are defined ("researcher" and "code-reviewer")
+- **THEN** the tool returns `[{"name": "researcher", "description": "Conducts web research"}, {"name": "code-reviewer", "description": "Reviews code for quality"}]`
+
+#### Scenario: List skills with no skills defined
+- **WHEN** the agent calls `list_skills` and no skills are defined
+- **THEN** the tool returns `[]`
+
+### Requirement: get_skill MCP tool
+The backend MCP server SHALL expose a `get_skill` tool that accepts a `name` parameter and returns the full `instructions` text of the matching skill. If no skill matches the given name, the tool SHALL return an error message indicating the skill was not found.
+
+#### Scenario: Get existing skill
+- **WHEN** the agent calls `get_skill` with name "researcher" and that skill exists
+- **THEN** the tool returns the full instructions text of the "researcher" skill
+
+#### Scenario: Get non-existent skill
+- **WHEN** the agent calls `get_skill` with name "nonexistent" and no skill has that name
+- **THEN** the tool returns an error message: "Skill 'nonexistent' not found"
+
+### Requirement: Skill-awareness directive in system prompt
+When the worker prepares the system prompt for a task, it SHALL check if any skills are defined in settings. If at least one skill exists, the worker SHALL append a skill-awareness directive to the system prompt instructing the agent to: (1) call `list_skills` at the start of execution to discover available skills, (2) call `get_skill` to load a skill if one is relevant to the task, and (3) follow the loaded skill's instructions. If no skills are defined, the worker SHALL NOT append the directive.
+
+#### Scenario: Skills exist — directive appended
+- **WHEN** the worker prepares the system prompt and 2 skills are defined in settings
+- **THEN** the system prompt written to the container includes the original admin prompt followed by a skill-awareness directive
+
+#### Scenario: No skills defined — no directive
+- **WHEN** the worker prepares the system prompt and no skills are defined in settings
+- **THEN** the system prompt written to the container contains only the original admin prompt (and any other existing augmentations like Perplexity)
+
+#### Scenario: Directive placement after Perplexity
+- **WHEN** the worker prepares the system prompt and both Perplexity and skills are enabled
+- **THEN** the skill-awareness directive appears after the Perplexity instruction block

--- a/openspec/specs/skill-library/spec.md
+++ b/openspec/specs/skill-library/spec.md
@@ -1,0 +1,54 @@
+## Requirements
+
+### Requirement: Skill data structure
+Each skill SHALL be a JSON object with the following fields: `id` (UUID string, auto-generated), `name` (string, unique, non-empty), `description` (string, non-empty, brief summary for discovery), and `instructions` (string, non-empty, full prompt text). Skills SHALL be stored as a JSON array under the `skills` key in the `Setting` table.
+
+#### Scenario: Skill structure
+- **WHEN** a skill is stored in settings
+- **THEN** it contains `id`, `name`, `description`, and `instructions` fields
+
+#### Scenario: Skills key not yet set
+- **WHEN** no `skills` key exists in the Setting table
+- **THEN** the system treats the skill list as an empty array
+
+### Requirement: Skills included in settings API
+The `GET /api/settings` endpoint SHALL return the `skills` array in its response. The `PUT /api/settings` endpoint SHALL accept a `skills` field containing the full skills array and persist it to the `Setting` table under the `skills` key. Saving skills SHALL require admin role.
+
+#### Scenario: Get settings includes skills
+- **WHEN** an authenticated user calls `GET /api/settings` and two skills are defined
+- **THEN** the response includes a `skills` array with both skill objects
+
+#### Scenario: Get settings with no skills defined
+- **WHEN** an authenticated user calls `GET /api/settings` and no skills key exists
+- **THEN** the response includes `skills` as an empty array
+
+#### Scenario: Save skills via settings
+- **WHEN** an admin calls `PUT /api/settings` with `{"skills": [{"id": "...", "name": "researcher", "description": "Web research skill", "instructions": "You are a research assistant..."}]}`
+- **THEN** the skills array is persisted and returned in subsequent `GET /api/settings` responses
+
+#### Scenario: Non-admin cannot save skills
+- **WHEN** a non-admin user calls `PUT /api/settings` with a `skills` field
+- **THEN** the request is rejected with HTTP 403
+
+### Requirement: Skills management UI
+The settings page SHALL include a collapsible "Skills" section that displays all defined skills. The section SHALL allow the admin to add a new skill (providing name, description, and instructions), edit an existing skill, and delete a skill. Each skill in the list SHALL display its name and description. The instructions field SHALL use a multi-line textarea.
+
+#### Scenario: Skills section visible on settings page
+- **WHEN** an admin navigates to the settings page
+- **THEN** a "Skills" section is visible (collapsed or expanded) showing the count of defined skills
+
+#### Scenario: Add a new skill
+- **WHEN** the admin clicks "Add Skill" and fills in name "researcher", description "Conducts web research", and instructions "You are a research specialist..."
+- **THEN** the skill is added to the list and saved to the backend
+
+#### Scenario: Edit an existing skill
+- **WHEN** the admin clicks edit on a skill and changes its instructions
+- **THEN** the updated skill is saved to the backend
+
+#### Scenario: Delete a skill
+- **WHEN** the admin clicks delete on a skill and confirms
+- **THEN** the skill is removed from the list and the change is saved to the backend
+
+#### Scenario: Skill name uniqueness
+- **WHEN** the admin tries to add a skill with a name that already exists
+- **THEN** the UI shows a validation error and does not save


### PR DESCRIPTION
## Summary

- Archive completed agent-skill-loader change
- Sync two new delta specs to main specs: skill-library, agent-skill-loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)