### PR TITLE
Archive add-post-tweet-tool and sync specs

### DIFF
--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-14

--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/design.md
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/design.md
@@ -1,0 +1,27 @@
+## Decisions
+
+### Decision: Use tweepy library for Twitter API v2
+Use the `tweepy` Python library to interact with the Twitter/X API v2. Tweepy handles OAuth 1.0a authentication and provides a clean interface for posting tweets. This avoids writing raw HTTP requests and managing OAuth signatures manually.
+
+### Decision: Credentials via environment variables
+Twitter API credentials are passed as environment variables on the backend service:
+- `TWITTER_API_KEY` — API key (consumer key)
+- `TWITTER_API_SECRET` — API secret (consumer secret)
+- `TWITTER_ACCESS_TOKEN` — Access token
+- `TWITTER_ACCESS_SECRET` — Access token secret
+
+This follows the same pattern as `OPENAI_API_KEY` and other service credentials. The tool returns an error if credentials are not configured.
+
+### Decision: Tool on the backend MCP server (not the container)
+The `post_tweet` tool runs on the backend MCP server, not inside the task runner container. This means:
+- Twitter credentials only need to be on the backend service, not passed into containers
+- The agent calls the tool via the `content-manager` MCP server (same as `list_skills`/`get_skill`)
+- No changes needed to the worker or container configuration
+
+### Decision: Message validation at the tool level
+The tool validates the message length (1-280 characters) before calling the Twitter API. Empty messages and messages exceeding 280 characters are rejected with a clear error message, without making an API call.
+
+## Constraints
+
+- Twitter API v2 free tier allows 1,500 tweets per month — no rate limiting implemented in this change, rely on Twitter's API to reject excess posts
+- The tool posts plain text tweets only (no media, threads, or replies in this iteration)

--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/proposal.md
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The task runner agent needs the ability to post tweets as part of its task execution (e.g., a "create twitter post" skill). Adding a `post_tweet` MCP tool to the backend server lets the agent publish tweets directly, using Twitter/X API credentials managed as environment variables on the backend service.
+
+## What Changes
+
+- Add a `post_tweet` MCP tool to `backend/mcp_server.py` that accepts a message (max 280 characters) and posts it to Twitter/X via the v2 API
+- Twitter API credentials (`TWITTER_BEARER_TOKEN`, `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_SECRET`) read from environment variables on the backend service
+- Add `tweepy` to backend dependencies for Twitter API interaction
+
+## Capabilities
+
+### New Capabilities
+- `twitter-posting`: MCP tool for posting tweets via the Twitter/X API
+
+### Modified Capabilities
+- `mcp-server-endpoint`: Adding a new tool to the existing MCP server
+
+## Impact
+
+- `backend/mcp_server.py` — new `post_tweet` tool function
+- `backend/requirements.txt` — add `tweepy` dependency
+- `docker-compose.yml` — add Twitter env vars to backend service
+- `helm/content-manager/templates/backend-deployment.yaml` — add Twitter secret env vars

--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/specs/mcp-server-endpoint/spec.md
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/specs/mcp-server-endpoint/spec.md
@@ -1,0 +1,5 @@
+## MODIFIED Requirements
+
+### Requirement: MCP endpoint listed in tool discovery
+- **WHEN** a client sends a `tools/list` request to `/mcp`
+- **THEN** the response includes the tools: `new_task`, `task_status`, `task_output`, `list_skills`, `get_skill`, `post_tweet`

--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/specs/twitter-posting/spec.md
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/specs/twitter-posting/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: post_tweet MCP tool
+The backend MCP server SHALL expose a `post_tweet` tool that accepts a `message` parameter (string, 1-280 characters) and posts it as a tweet via the Twitter/X API v2. The tool SHALL return the posted tweet's URL on success or an error message on failure. The tool SHALL require valid MCP API key authentication.
+
+#### Scenario: Post a valid tweet
+- **WHEN** the agent calls `post_tweet` with message "Hello from content-manager!"
+- **THEN** the tool posts the tweet and returns the tweet URL (e.g., "Tweet posted: https://x.com/user/status/123456")
+
+#### Scenario: Message too long
+- **WHEN** the agent calls `post_tweet` with a message exceeding 280 characters
+- **THEN** the tool returns an error: "Message exceeds 280 character limit (got N characters)"
+
+#### Scenario: Empty message
+- **WHEN** the agent calls `post_tweet` with an empty message
+- **THEN** the tool returns an error: "Message cannot be empty"
+
+#### Scenario: Twitter credentials not configured
+- **WHEN** the agent calls `post_tweet` and Twitter API credentials are not set in environment variables
+- **THEN** the tool returns an error: "Twitter API credentials not configured"
+
+#### Scenario: Twitter API error
+- **WHEN** the agent calls `post_tweet` and the Twitter API returns an error (e.g., rate limit, auth failure)
+- **THEN** the tool returns an error message including the Twitter API error details

--- a/openspec/changes/archive/2026-02-14-add-post-tweet-tool/tasks.md
+++ b/openspec/changes/archive/2026-02-14-add-post-tweet-tool/tasks.md
@@ -1,0 +1,16 @@
+## 1. Backend — Dependencies
+
+- [x] 1.1 Add `tweepy` to `backend/requirements.txt` and install into the backend venv.
+
+## 2. Backend — MCP Tool
+
+- [x] 2.1 Add `post_tweet` tool to `backend/mcp_server.py`. Accepts a `message` parameter (string). Validates length (1-280 chars). Uses `tweepy` with OAuth 1.0a credentials from env vars (`TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_SECRET`) to post via Twitter API v2. Returns the tweet URL on success or an error message on failure.
+
+## 3. Configuration
+
+- [x] 3.1 Add Twitter env vars to `docker-compose.yml` on the backend service (with `${VAR:-}` defaults so they're optional).
+- [x] 3.2 Add Twitter secret env vars to `helm/content-manager/templates/backend-deployment.yaml` (conditional on a `twitter.existingSecret` value, following the Perplexity pattern).
+
+## 4. Tests
+
+- [x] 4.1 Add backend tests for `post_tweet`: valid tweet (mock tweepy), message too long, empty message, credentials not configured, Twitter API error. Update the tool count assertion test.

--- a/openspec/specs/mcp-server-endpoint/spec.md
+++ b/openspec/specs/mcp-server-endpoint/spec.md
@@ -12,7 +12,7 @@ The backend SHALL mount an MCP Streamable HTTP server at the `/mcp` path using t
 #### Scenario: MCP endpoint listed in tool discovery
 
 - **WHEN** a client sends a `tools/list` request to `/mcp`
-- **THEN** the response includes the three tools: `new_task`, `task_status`, `task_output`
+- **THEN** the response includes the tools: `new_task`, `task_status`, `task_output`, `list_skills`, `get_skill`, `post_tweet`
 
 ### Requirement: API key authentication via TokenVerifier
 

--- a/openspec/specs/twitter-posting/spec.md
+++ b/openspec/specs/twitter-posting/spec.md
@@ -1,0 +1,24 @@
+## Requirements
+
+### Requirement: post_tweet MCP tool
+The backend MCP server SHALL expose a `post_tweet` tool that accepts a `message` parameter (string, 1-280 characters) and posts it as a tweet via the Twitter/X API v2. The tool SHALL return the posted tweet's URL on success or an error message on failure. The tool SHALL require valid MCP API key authentication.
+
+#### Scenario: Post a valid tweet
+- **WHEN** the agent calls `post_tweet` with message "Hello from content-manager!"
+- **THEN** the tool posts the tweet and returns the tweet URL (e.g., "Tweet posted: https://x.com/user/status/123456")
+
+#### Scenario: Message too long
+- **WHEN** the agent calls `post_tweet` with a message exceeding 280 characters
+- **THEN** the tool returns an error: "Message exceeds 280 character limit (got N characters)"
+
+#### Scenario: Empty message
+- **WHEN** the agent calls `post_tweet` with an empty message
+- **THEN** the tool returns an error: "Message cannot be empty"
+
+#### Scenario: Twitter credentials not configured
+- **WHEN** the agent calls `post_tweet` and Twitter API credentials are not set in environment variables
+- **THEN** the tool returns an error: "Twitter API credentials not configured"
+
+#### Scenario: Twitter API error
+- **WHEN** the agent calls `post_tweet` and the Twitter API returns an error (e.g., rate limit, auth failure)
+- **THEN** the tool returns an error message including the Twitter API error details


### PR DESCRIPTION
## Summary
- Archive completed add-post-tweet-tool change
- Sync new twitter-posting spec to main specs
- Update mcp-server-endpoint spec with post_tweet in tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)