### PR TITLE
Make cloud-service httpx clients follow redirects

### DIFF
--- a/errand/cloud_auth.py
+++ b/errand/cloud_auth.py
@@ -18,7 +18,7 @@ async def exchange_code(cloud_url: str, code: str) -> dict:
     Raises httpx.HTTPStatusError on failure.
     """
     url = f"{cloud_url.rstrip('/')}/auth/tenant/token"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
         resp = await client.post(url, json={"code": code})
         resp.raise_for_status()
         return resp.json()
@@ -31,7 +31,7 @@ async def refresh_token(cloud_url: str, refresh_token_value: str) -> dict:
     Raises httpx.HTTPStatusError on failure.
     """
     url = f"{cloud_url.rstrip('/')}/auth/tenant/refresh"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
         resp = await client.post(url, json={"refresh_token": refresh_token_value})
         resp.raise_for_status()
         return resp.json()

--- a/errand/cloud_endpoints.py
+++ b/errand/cloud_endpoints.py
@@ -38,7 +38,7 @@ async def register_cloud_endpoints(
     api_url = f"{cloud_service_url.rstrip('/')}/api/endpoints"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.post(
                 api_url,
                 json={
@@ -110,7 +110,7 @@ async def revoke_cloud_endpoints(cloud_creds: dict, cloud_service_url: str) -> N
     api_url = f"{cloud_service_url.rstrip('/')}/api/endpoints?integration=slack"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.delete(
                 api_url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -135,7 +135,7 @@ async def check_existing_endpoints(cloud_creds: dict, cloud_service_url: str) ->
     api_url = f"{cloud_service_url.rstrip('/')}/api/endpoints?integration=slack"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.get(
                 api_url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -252,7 +252,7 @@ async def register_webhook_trigger_endpoint(
     api_url = f"{cloud_service_url.rstrip('/')}/api/endpoints"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.post(
                 api_url,
                 json={
@@ -288,7 +288,7 @@ async def deregister_webhook_trigger_endpoint(
     api_url = f"{cloud_service_url.rstrip('/')}/api/endpoints?integration={integration}&trigger_id={trigger_id}"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.delete(
                 api_url,
                 headers={"Authorization": f"Bearer {access_token}"},
@@ -362,7 +362,7 @@ async def fetch_subscription_status(
     api_url = f"{cloud_service_url.rstrip('/')}/api/subscription"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             resp = await client.get(
                 api_url,
                 headers={"Authorization": f"Bearer {access_token}"},


### PR DESCRIPTION
## Summary

`httpx.AsyncClient` defaults to `follow_redirects=False`. After errand-cloud's apex flip — `errand.cloud` is now the canonical 200 host and `service.errand.cloud` 308s to it — every existing tenant whose stored \`cloud_service_url\` is still \`https://service.errand.cloud\` sees their cloud API calls fail at the redirect with:

\`\`\`
httpx.HTTPStatusError: Redirect response '308 Permanent Redirect'
  for url 'https://service.errand.cloud/auth/tenant/token'
  Redirect location: 'https://errand.cloud/auth/tenant/token'
\`\`\`

The Connect-to-Cloud OAuth flow finishes Keycloak successfully but the token-exchange POST throws, so the connection never establishes.

This PR sets \`follow_redirects=True\` on every cloud-service-facing httpx client (eight call sites across \`cloud_auth.py\` and \`cloud_endpoints.py\`). Tenants on the legacy URL transparently keep working; tenants pointed at the new canonical URL behave identically.

External-OAuth callers (\`cloud_storage.py\`, \`integration_routes.py\`) are intentionally not touched in this PR — their failure mode is different and out of scope.

## Test plan

- [x] Unit-equivalent: every changed call site uses the response body, not the \`Location\` header, so transparently following the redirect is a behaviour-preserving change for the success path.
- [ ] Run \`pytest\` locally (no test changes needed; existing tests stub httpx calls).
- [ ] After deploy: existing tenant with \`cloud_service_url=https://service.errand.cloud\` completes the Connect-to-Cloud flow without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)